### PR TITLE
mongoose update

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "helmet": "^0.5.0",
     "jade": "^1.6.0",
     "method-override": "^2.2.0",
-    "mongoose": "4.0.1",
+    "mongoose": "^4.1.10",
     "morgan": "^1.3.0",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",


### PR DESCRIPTION
The older mongoose version causes the app to crash on installation with
`Error: Cannot find module 'mongodb/node_modules/mongodb-core/node_modules/bson/lib/bson/objectid'`

Updating to lastest mongoose fixes this.
